### PR TITLE
Initial version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,40 @@
+{
+	"name": "wpsyntex/dynamo",
+	"description": "Improves the performance of WordPress translation",
+	"license": "GPL-3.0-or-later",
+	"homepage": "https://polylang.pro",
+	"type": "wordpress-plugin",
+	"require": {
+		"php": ">=5.6"
+	},
+	"require-dev": {
+		"wpsyntex/polylang-phpstan": "dev-master",
+		"dealerdirect/phpcodesniffer-composer-installer": "*",
+		"wp-coding-standards/wpcs": "*",
+		"automattic/vipwpcs": "*",
+		"phpcompatibility/phpcompatibility-wp": "*",
+		"yoast/phpunit-polyfills": "^1.0"
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"test":"vendor/bin/phpunit",
+		"cs":"vendor/bin/phpcs",
+		"stan": "vendor/bin/phpstan analyze --memory-limit=400M",
+		"lint": [
+			"@cs",
+			"@stan"
+		]
+	},
+	"scripts-descriptions": {
+		"test":"Runs PHPUnit tests.",
+		"cs":"Runs PHPCS linter.",
+		"stan": "Runs PHPStan analysis.",
+		"lint": "Runs both PHPCS and PHPStan."
+	}
+}

--- a/dynamo.php
+++ b/dynamo.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * DynaMo
+ *
+ * @package           DynaMo
+ * @author            WP SYNTEX
+ * @license           GPL-2.0-or-later
+ *
+ * @wordpress-plugin
+ * Plugin Name:       DynaMo
+ * Plugin URI:        https://polylang.pro
+ * Description:       Improves the WordPress translations performance
+ * Version:           1.0-dev
+ * Requires at least: 5.2
+ * Requires PHP:      5.6
+ * Author:            WP SYNTEX
+ * Author URI:        https://polylang.pro
+ * Text Domain:       dynamo
+ * Domain Path:       /languages
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * Copyright 2021 WP SYNTEX
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This program incorporates work from the plugin WP Performance Pack
+ * Copyright 2014-2020 Björn Ahrens (email : bjoern@ahrens.net)
+ * WP Performance Pack is released under the GPL V2 or later.
+ */
+
+namespace WP_Syntex\DynaMo;
+
+require __DIR__ . '/vendor/autoload.php';
+( new Plugin() )->add_hooks();

--- a/src/binary-search.php
+++ b/src/binary-search.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Binary_Search class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * Implements the search algorithm using a binary search, useful when no hash table is provided.
+ * See dcigettext.c in GNU gettext.
+ *
+ * @since 1.0
+ */
+class Binary_Search implements Search_Handler {
+	/**
+	 * Stream handle.
+	 *
+	 * @var resource
+	 */
+	protected $handle;
+
+	/**
+	 * An array containing the length and position of the original strings.
+	 *
+	 * @var \SplFixedArray<int>
+	 */
+	protected $originals_table;
+
+	/**
+	 * An array containing the length and position of the translated strings.
+	 *
+	 * @var \SplFixedArray<int>
+	 */
+	protected $translations_table;
+
+	/**
+	 * The total count of translated strings.
+	 *
+	 * @var int
+	 */
+	protected $total;
+
+	/**
+	 * An array to store strings already read.
+	 *
+	 * @var string[]
+	 */
+	private $originals;
+
+	/**
+	 * Constructor
+	 *
+	 * @since 1.0
+	 *
+	 * @param resource            $handle             Stream handle.
+	 * @param \SplFixedArray<int> $originals_table    An array containing the length and position of the original strings.
+	 * @param \SplFixedArray<int> $translations_table An array containing the length and position of the translated strings.
+	 * @param int                 $total              The total count of translated strings.
+	 */
+	public function __construct( $handle, $originals_table, $translations_table, $total ) {
+		$this->handle = $handle;
+
+		$this->originals_table    = $originals_table;
+		$this->translations_table = $translations_table;
+		$this->total              = $total;
+	}
+
+	/**
+	 * Returns the translation(s) given an original key.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $key The key of the string to translate (includes the context and singular string).
+	 * @return string|false
+	 */
+	public function get_translation( $key ) {
+		$left  = 0;
+		$right = $this->total;
+
+		while ( $left < $right ) {
+			$pos = (int) ( ( $left + $right ) / 2 );
+			$i   = $pos * 2; // Due to position and length of strings stored alternately in the same flat array.
+
+			if ( ! isset( $this->originals[ $pos ] ) ) {
+				if ( $this->originals_table[ $i ] > 0 ) {
+					\fseek( $this->handle, (int) $this->originals_table[ $i + 1 ] );
+					$this->originals[ $pos ] = (string) \fread( $this->handle, (int) $this->originals_table[ $i ] );
+				} else {
+					$this->originals[ $pos ] = '';
+				}
+			}
+
+			/*
+			 * For plurals, we limit the comparison to the length of the searched key
+			 * because the key doesn't include the plural form while the original does.
+			 */
+			$length = \strpos( $this->originals[ $pos ], "\0" );
+			$cmp    = $length ? \strncmp( $key, $this->originals[ $pos ], $length ) : \strcmp( $key, $this->originals[ $pos ] );
+
+			if ( $cmp < 0 ) {
+				$right = $pos;
+			} elseif ( $cmp > 0 ) {
+				$left = $pos + 1;
+			} else {
+				\fseek( $this->handle, (int) $this->translations_table[ $i + 1 ] );
+				return \fread( $this->handle, (int) $this->translations_table[ $i ] );
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/hash-search.php
+++ b/src/hash-search.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Hash_Search class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * Implements the search algorithm using the hash table which should be a bit faster
+ * than the alternative binary search.
+ * See dcigettext.c in GNU gettext.
+ *
+ * @since 1.0
+ */
+class Hash_Search implements Search_Handler {
+	/**
+	 * Stream handle.
+	 *
+	 * @var resource
+	 */
+	protected $handle;
+
+	/**
+	 * An array containing the length and position of the original strings.
+	 *
+	 * @var \SplFixedArray<int>
+	 */
+	protected $originals_table;
+
+	/**
+	 * An array containing the length and position of the translated strings.
+	 *
+	 * @var \SplFixedArray<int>
+	 */
+	protected $translations_table;
+
+	/**
+	 * The hash table.
+	 *
+	 * @var \SplFixedArray<int>
+	 */
+	protected $hash_table;
+
+	/**
+	 * The length of the hash table.
+	 *
+	 * @var int
+	 */
+	protected $hash_length;
+
+	/**
+	 * An array to store strings already read.
+	 *
+	 * @var string[]
+	 */
+	private $originals;
+
+	/**
+	 * Constructor
+	 *
+	 * @since 1.0
+	 *
+	 * @param resource            $handle             Stream handle.
+	 * @param \SplFixedArray<int> $originals_table    An array containing the length and position of the original strings.
+	 * @param \SplFixedArray<int> $translations_table An array containing the length and position of the translated strings.
+	 * @param \SplFixedArray<int> $hash_table         The hash table.
+	 * @param int                 $hash_length        The length of the hash table.
+	 */
+	public function __construct( $handle, $originals_table, $translations_table, $hash_table, $hash_length ) {
+		$this->handle = $handle;
+
+		$this->originals_table    = $originals_table;
+		$this->translations_table = $translations_table;
+		$this->hash_table         = $hash_table;
+		$this->hash_length        = $hash_length;
+	}
+
+	/**
+	 * Returns the translation(s) given an original key.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $key The key of the string to translate (includes the context and singular string).
+	 * @return string|false
+	 */
+	public function get_translation( $key ) {
+		$length = \strlen( $key );
+
+		/*
+		 * Evaluates the hash with the "hashpjw" function by P.J. Weinberger.
+		 * See hash-string.c in GNU gettext.
+		 */
+		$hash_val = 0;
+		$chars    = \unpack( 'C*', $key );
+		foreach ( (array) $chars as $char ) {
+			$hash_val = ( $hash_val << 4 ) + $char;
+			$g        = $hash_val & 0xF0000000;
+			if ( 0 !== $g ) {
+				$hash_val ^= $g >> 24;
+				$hash_val ^= $g;
+			}
+		}
+
+		$idx  = $hash_val % $this->hash_length;
+		$incr = 1 + ( $hash_val % ( $this->hash_length - 2 ) );
+
+		while ( ! empty( $this->hash_table[ $idx ] ) ) {
+			$pos = $this->hash_table[ $idx ] - 1;
+			$i   = $pos * 2; // Due to position and length of strings stored alternately in the same flat array.
+
+			if ( ! isset( $this->originals[ $pos ] ) && $this->originals_table[ $i ] >= $length ) {
+				\fseek( $this->handle, (int) $this->originals_table[ $i + 1 ] );
+				$this->originals[ $pos ] = (string) \fread( $this->handle, (int) $this->originals_table[ $i ] );
+			}
+
+			/*
+			 * We limit the comparison to the length of the searched key
+			 * because the key doesn't include the plural form while the original does.
+			 */
+			if ( isset( $this->originals[ $pos ] ) && 0 === strncmp( $key, $this->originals[ $pos ], $length ) ) {
+				\fseek( $this->handle, (int) $this->translations_table[ $i + 1 ] );
+				return \fread( $this->handle, (int) $this->translations_table[ $i ] );
+			}
+
+			$max_idx = $this->hash_length - $incr;
+			if ( $idx >= $max_idx ) {
+				$idx -= $max_idx;
+			} else {
+				$idx += $incr;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/mo-reader.php
+++ b/src/mo-reader.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * MO_Reader class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * A class to read MO files.
+ *
+ * @since 1.0
+ */
+class MO_Reader {
+
+	/**
+	 * The object handling the translations search algorithm.
+	 *
+	 * @var Search_Handler
+	 */
+	protected $search_handler;
+
+	/**
+	 * The plural expression founded in the MO file.
+	 *
+	 * @var string
+	 */
+	protected $plural_expression;
+
+	/**
+	 * Parses the MO file.
+	 *
+	 * @see https://www.gnu.org/software/gettext/manual/gettext.html#MO-Files
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/mo.php#L213-L301
+	 *
+	 * @since 1.0
+	 *
+	 * @param resource $handle Stream handle.
+	 * @return bool True if successful, false otherwise.
+	 */
+	public function parse( $handle ) {
+		rewind( $handle );
+
+		// Read the magic number and get the endianness of the file.
+		$magic = fread( $handle, 4 );
+		if ( ! $magic ) {
+			return false;
+		}
+
+		$endian = self::get_byteorder( $magic );
+		if ( false === $endian ) {
+			return false;
+		}
+
+		// Read and parse the header.
+		$header = fread( $handle, 24 );
+		if ( ! $header || $this->strlen( $header ) !== 24 ) {
+			return false;
+		}
+
+		$header = unpack( "{$endian}revision/{$endian}total/{$endian}originals_lengths_addr/{$endian}translations_lengths_addr/{$endian}hash_length/{$endian}hash_addr", $header );
+		if ( ! is_array( $header ) ) {
+			return false;
+		}
+
+		// Support revision 0 of MO format specs, only.
+		if ( 0 !== $header['revision'] ) {
+			return false;
+		}
+
+		// Seek to data blocks.
+		fseek( $handle, $header['originals_lengths_addr'] );
+
+		// Read originals' indices.
+		$originals_lengths_length = $header['translations_lengths_addr'] - $header['originals_lengths_addr'];
+		if ( $originals_lengths_length !== $header['total'] * 8 ) {
+			return false;
+		}
+
+		$originals = self::read_and_unpack( $handle, $endian, $header['total'] * 2 );
+		if ( ! $originals ) {
+			return false;
+		}
+
+		// Read translations' indices.
+		$translations_lengths_length = $header['hash_addr'] - $header['translations_lengths_addr'];
+		if ( $translations_lengths_length !== $header['total'] * 8 ) {
+			return false;
+		}
+
+		$translations = self::read_and_unpack( $handle, $endian, $header['total'] * 2 );
+		if ( ! $translations ) {
+			return false;
+		}
+
+		if ( $header['hash_length'] > 0 && PHP_INT_SIZE === 8 ) {
+			// If we have a hash table and PHP supports 64 bits, read it and use it for searching translations.
+			$hashes = self::read_and_unpack( $handle, $endian, $header['hash_length'] );
+			if ( ! $hashes ) {
+				return false;
+			}
+
+			// The usage of SplFixedArray instead of arrays should slightly increase the access speed.
+			$this->search_handler = new Hash_Search(
+				$handle,
+				\SplFixedArray::fromArray( $originals, false ),
+				\SplFixedArray::fromArray( $translations, false ),
+				\SplFixedArray::fromArray( $hashes, false ),
+				$header['hash_length']
+			);
+		} else {
+			// Otherwise use the binary search.
+			$this->search_handler = new Binary_Search(
+				$handle,
+				\SplFixedArray::fromArray( $originals, false ),
+				\SplFixedArray::fromArray( $translations, false ),
+				$header['total']
+			);
+		}
+
+		// Search the translation headers (usually at first position) and use them to get the plural expression.
+		$headers_idx = array_search( 0, $originals, true );
+		if ( false === $headers_idx ) {
+			return false;
+		}
+
+		fseek( $handle, $translations[ (int) $headers_idx + 1 ] );
+		$headers = fread( $handle, $translations[ (int) $headers_idx ] );
+		if ( ! $headers ) {
+			return false;
+		}
+
+		$this->plural_expression = $this->parse_plural_forms_expression( $headers );
+		return true;
+	}
+
+	/**
+	 * Returns an instance to the MO search handler.
+	 *
+	 * @since 1.0
+	 *
+	 * @return Search_Handler
+	 */
+	public function get_search_handler() {
+		return $this->search_handler;
+	}
+
+	/**
+	 * Returns the plural expression.
+	 *
+	 * @since 1.0
+	 *
+	 * @return string
+	 */
+	public function get_plural_expression() {
+		return $this->plural_expression;
+	}
+
+	/**
+	 * Returns the unpack format for the endianness of the file.
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/mo.php#L192-L211
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $magic Magic read from the file.
+	 * @return string|false
+	 */
+	protected static function get_byteorder( $magic ) {
+		$magic = unpack( 'V', $magic );
+		if ( ! $magic ) {
+			return false;
+		}
+
+		$magic = reset( $magic );
+
+		// Little endian, second case for 32 bits.
+		if ( 0x950412de === $magic || ( PHP_INT_SIZE === 4 && -1794895138 === $magic ) ) {
+			return 'V';
+		}
+
+		// Big endian, second case for 32 bits.
+		if ( 0xde120495 === $magic || ( PHP_INT_SIZE === 4 && -569244523 === $magic ) ) {
+			return 'N';
+		}
+
+		return false;
+	}
+
+	/**
+	 * Reads and unpacks a table of integers, typically used to read the tables
+	 * for original strings table, translations table and hashes table.
+	 *
+	 * @since 1.0
+	 *
+	 * @param resource $handle Stream handle.
+	 * @param string   $endian 'N' or 'V' depending on the endianness of the file.
+	 * @param int      $length The number of values to read.
+	 * @return int[]|false
+	 */
+	protected static function read_and_unpack( $handle, $endian, $length ) {
+		$strings = fread( $handle, $length * 4 );
+		if ( ! $strings || self::strlen( $strings ) !== $length * 4 ) {
+			return false;
+		}
+
+		return unpack( $endian . $length, $strings );
+	}
+
+	/**
+	 * Returns the length of a string.
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/streams.php#L99-L109
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $string The string.
+	 * @return int
+	 */
+	protected static function strlen( $string ) {
+		if ( function_exists( 'mb_strlen' ) && ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
+			return mb_strlen( $string, 'ascii' );
+		} else {
+			return strlen( $string );
+		}
+	}
+
+	/**
+	 * Sets the plural expression from the translations headers.
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/translations.php#L265-L295
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/translations.php#L202-L214
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $headers Translations headers read from the MO file.
+	 * @return string
+	 */
+	protected function parse_plural_forms_expression( $headers ) {
+		// Sometimes \n's are used instead of real new lines.
+		$headers = str_replace( '\n', "\n", $headers );
+		$lines   = explode( "\n", $headers );
+
+		foreach ( $lines as $line ) {
+			if ( false !== strpos( $line, 'Plural-Forms' ) ) {
+				$parts = explode( ':', $line, 2 );
+				if ( preg_match( '/^\s*nplurals\s*=\s*(\d+)\s*;\s+plural\s*=\s*(.+)$/', $parts[1], $matches ) ) {
+					return rtrim( trim( $matches[2] ), ';' );
+				}
+			}
+		}
+
+		return 'n != 1'; // The default value (en_US).
+	}
+}

--- a/src/mo.php
+++ b/src/mo.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * MO Class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * A class defining objects usable in the WordPress global $l10n array.
+ *
+ * @since 1.0
+ */
+class MO {
+
+	/**
+	 * Empty array.
+	 *
+	 * It is there only in case someone attempts to directly merge an instance
+	 * of this class into a WordPress MO object.
+	 *
+	 * @var \Translation_Entry[]
+	 */
+	public $entries = array();
+
+	/**
+	 * Stores all translations for (maybe) next calls.
+	 *
+	 * @var string[]
+	 */
+	protected $cache = array();
+
+	/**
+	 * An array of objects handling the translations search in files loaded by this class.
+	 *
+	 * @var Search_Handler[]
+	 */
+	protected $items = array();
+
+	/**
+	 * An instance of the WordPress Plural_Forms class.
+	 *
+	 * @var \Plural_Forms
+	 */
+	protected $plural_forms_handler;
+
+	/**
+	 * Imports a MO file.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * The whole file is copied into the memory as it's expected to slightly increase
+	 * the speed of the numerous calls to fseek() and fread().
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $filename Path to the MO file.
+	 * @return bool
+	 */
+	public function import_from_file( $filename ) {
+		$file_handle = fopen( $filename, 'rb' );
+		$mem_handle  = fopen( 'php://memory', 'w+b' );
+
+		if ( ! $file_handle || ! $mem_handle ) {
+			return false;
+		}
+
+		stream_copy_to_stream( $file_handle, $mem_handle );
+		fclose( $file_handle );
+
+		$reader = new MO_Reader();
+		if ( ! $reader->parse( $mem_handle ) ) {
+			return false;
+		}
+
+		$this->plural_forms_handler = new \Plural_Forms( $reader->get_plural_expression() );
+
+		$this->items[] = $reader->get_search_handler();
+		return true;
+	}
+
+	/**
+	 * Merges an existing MO file into this one.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * @since 1.0
+	 *
+	 * @param MO $other Other instance to merge to the current instance.
+	 * @return void
+	 */
+	public function merge_with( &$other ) {
+		if ( $other instanceof MO ) {
+			$this->items = array_merge( $other->get_items(), $this->items );
+		}
+	}
+
+	/**
+	 * Retrieves translated string with gettext context.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string      $singular Text to translate.
+	 * @param string|null $context  Context information for the translators.
+	 * @return string
+	 */
+	public function translate( $singular, $context = null ) {
+		// _get_plugin_data_markup_translate() may call translate() with an empty string.
+		if ( empty( $singular ) ) {
+			return $singular;
+		}
+
+		$key = ! $context ? $singular : $context . "\4" . $singular;
+
+		if ( isset( $this->cache[ $key ] ) ) {
+			return $this->cache[ $key ];
+		}
+
+		foreach ( $this->items as $item ) {
+			$translation = $item->get_translation( $key );
+			if ( ! empty( $translation ) ) {
+				$this->cache[ $key ] = $translation;
+				return $translation;
+			}
+		}
+
+		$this->cache[ $key ] = $singular; // Default in case we don't find a translation.
+		return $singular;
+	}
+
+	/**
+	 * Translates and retrieves the singular or plural form based on the supplied number, with gettext context.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string      $singular The text to be used if the number is singular.
+	 * @param string      $plural   The text to be used if the number is plural.
+	 * @param int         $count    The number to compare against to use either the singular or plural form.
+	 * @param string|null $context  Context information for the translators.
+	 * @return string
+	 */
+	public function translate_plural( $singular, $plural, $count, $context = null ) {
+		$key = ! $context ? $singular : $context . "\4" . $singular;
+
+		if ( ! isset( $this->cache[ $key ] ) ) {
+			foreach ( $this->items as $item ) {
+				$translation = $item->get_translation( $key );
+				if ( ! empty( $translation ) ) {
+					$this->cache[ $key ] = $translation;
+					break;
+				}
+			}
+		}
+
+		if ( isset( $this->cache[ $key ] ) ) {
+			$translations = explode( "\0", $this->cache[ $key ] );
+			$index        = $this->plural_forms_handler->get( $count );
+			if ( isset( $translations[ $index ] ) ) {
+				return $translations[ $index ];
+			}
+		}
+
+		return 1 === (int) $count ? $singular : $plural;
+	}
+
+	/**
+	 * Returns the MO search handlers included in this instance.
+	 *
+	 * @since 1.0
+	 *
+	 * @return Search_Handler[]
+	 */
+	public function get_items() {
+		return $this->items;
+	}
+}

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Plugin class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * The main plugin class.
+ *
+ * @since 1.0
+ */
+class Plugin {
+	/**
+	 * Add hooks
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
+	 */
+	public function add_hooks() {
+		add_filter( 'override_load_textdomain', array( $this, 'override_load_textdomain' ), 0, 3 );
+	}
+
+	/**
+	 * Filters whether to override the .mo file loading.
+	 *
+	 * @since 1.0
+	 *
+	 * @param bool   $override Whether to override the .mo file loading.
+	 * @param string $domain   Text domain. Unique identifier for retrieving translated strings.
+	 * @param string $mofile   Path to the MO file.
+	 * @return bool
+	 */
+	public function override_load_textdomain( $override, $domain, $mofile ) {
+		global $l10n;
+
+		if ( ! is_readable( $mofile ) ) {
+			return false;
+		}
+
+		$mo = new MO();
+		if ( ! $mo->import_from_file( $mofile ) ) {
+			return false;
+		}
+
+		if ( isset( $l10n[ $domain ] ) ) {
+			$mo->merge_with( $l10n[ $domain ] );
+		}
+
+		$l10n[ $domain ] = &$mo; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return true;
+	}
+}

--- a/src/search-handler.php
+++ b/src/search-handler.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Search_Handler interface
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * Interface for algorithms to search translations in a MO file.
+ *
+ * @since 1.0
+ */
+interface Search_Handler {
+	/**
+	 * Returns the translation(s) given an original key.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $key The key of the string to translate (includes the context and singular string).
+	 * @return string|false
+	 */
+	public function get_translation( $key );
+}


### PR DESCRIPTION
This PR is the first version of the plugin.

In the current WordPress version (5.8), all .mo files are loaded into memory and [transformed in an array](https://github.com/WordPress/WordPress/blob/489b33c97a8942e43c92f3d4a5efe069fecccb32/wp-includes/pomo/mo.php#L279-L298). This makes the translation itself (basically access to an array) quite fast, but processing all translations just after the .mo file is loaded is very slow. The whole process is inefficient is a file includes a lot of translations and only a few of them are fianlly used.

On the other hand, the original GNU Gettext library loads only a few part of the file (the headers and indexes tables to search strings and translations) and looks for the translation in the file only when needed. Two search algorithms are used depending on the presence of an optionnal hash table in the .mo file. This process has been implemented for WordPress in the [WP Performance Pack plugin](https://plugins.trac.wordpress.org/browser/wp-performance-pack/tags/2.4/modules/l10n_improvements/class.wppp_mo_dynamic.php). Unfortunately, this plugin has not been updated for 15 months to date and has not reached a high number of users. Compared to the WordPress current solution, this process is thus very fast to initialize the translation file and a bit slower for each translation. As long as the goal is not to use (almost) all translations of a file, it is overall much more efficient.

This plugin is a new implementation written from scratch with the process used by (GNU Gettext and) WP Performance Pack. It uses parts of WP and WPPP. Here are some explanations for my choices::
- The file is fully loaded in memory at the beginning. Accesses for searching strings are expected to be a bit faster. This comes to the price to more memory usage than WPPP, although still less than the current implementation of WP. This also allows not to care about files left open.
- Parsing the headers in the search for the plural expression has been simplified compared to WP as we don't need to precess all headers.
- The hash algorithm is implemented only for 64 bits platforms
- From code perspective, I used tried to use OOP. For example, the 2 search algorithms are implemented in 2 different classes sharing the same interface.
- I of course don't care of PHP < 5.6
- The minimum WP version is set to 5.2 only for test reasons (this is the oldest version compatible with the non-backward compatible methods introduced with WP 5.9). I expect however that the code could work down to WP 4.7 when the `Plural_Forms` class has been introduced. I however don't plan any test to verify this.
- In the eventuality that part of this code lands in WordPress, I selected the license GPL V2 or later (instead of V3 for our other plugins). In the same eventuality, the code is written according to the WP coding standards rather than our own.
