### PR TITLE
Don't store plural forms in search handlers cache

### DIFF
--- a/src/binary-search.php
+++ b/src/binary-search.php
@@ -86,18 +86,16 @@ class Binary_Search implements Search_Handler {
 			if ( ! isset( $this->originals[ $pos ] ) ) {
 				if ( $this->originals_table[ $i ] > 0 ) {
 					\fseek( $this->handle, (int) $this->originals_table[ $i + 1 ] );
-					$this->originals[ $pos ] = (string) \fread( $this->handle, (int) $this->originals_table[ $i ] );
+					$original = (string) \fread( $this->handle, (int) $this->originals_table[ $i ] );
+					$parts    = explode( "\0", $original ); // Remove the plural forms for the comparison with the searched key.
+
+					$this->originals[ $pos ] = $parts[0];
 				} else {
 					$this->originals[ $pos ] = '';
 				}
 			}
 
-			/*
-			 * For plurals, we limit the comparison to the length of the searched key
-			 * because the key doesn't include the plural form while the original does.
-			 */
-			$length = \strpos( $this->originals[ $pos ], "\0" );
-			$cmp    = $length ? \strncmp( $key, $this->originals[ $pos ], $length ) : \strcmp( $key, $this->originals[ $pos ] );
+			$cmp = \strcmp( $key, $this->originals[ $pos ] );
 
 			if ( $cmp < 0 ) {
 				$right = $pos;

--- a/src/hash-search.php
+++ b/src/hash-search.php
@@ -114,6 +114,7 @@ class Hash_Search implements Search_Handler {
 				\fseek( $this->handle, (int) $this->originals_table[ $i + 1 ] );
 				$original = (string) \fread( $this->handle, (int) $this->originals_table[ $i ] );
 				$parts    = explode( "\0", $original ); // Remove the plural forms for the comparison with the searched key.
+
 				$this->originals[ $pos ] = $parts[0];
 			}
 

--- a/src/hash-search.php
+++ b/src/hash-search.php
@@ -112,14 +112,16 @@ class Hash_Search implements Search_Handler {
 
 			if ( ! isset( $this->originals[ $pos ] ) && $this->originals_table[ $i ] >= $length ) {
 				\fseek( $this->handle, (int) $this->originals_table[ $i + 1 ] );
-				$this->originals[ $pos ] = (string) \fread( $this->handle, (int) $this->originals_table[ $i ] );
+				$original = (string) \fread( $this->handle, (int) $this->originals_table[ $i ] );
+				$parts    = explode( "\0", $original ); // Remove the plural forms for the comparison with the searched key.
+				$this->originals[ $pos ] = $parts[0];
 			}
 
 			/*
 			 * We limit the comparison to the length of the searched key
 			 * because the key doesn't include the plural form while the original does.
 			 */
-			if ( isset( $this->originals[ $pos ] ) && 0 === strncmp( $key, $this->originals[ $pos ], $length ) ) {
+			if ( isset( $this->originals[ $pos ] ) && $key === $this->originals[ $pos ] ) {
 				\fseek( $this->handle, (int) $this->translations_table[ $i + 1 ] );
 				return \fread( $this->handle, (int) $this->translations_table[ $i ] );
 			}


### PR DESCRIPTION
The searched key doesn't include the plural form. Only the context and the singular. It's thus easier to compare the searched string to the strings stored in the search handle `$originals` array if this array stores the strings without the plural form.

- For the binary search, this avoids to check if we should use `strncmp()` or `strcmp()`.
- For the hash search, this allows to use a direct comparison instead of `strncmp()` (I was not 100% sure of the robustness of this comparison). 