### PR TITLE
Prepare the possibility to use other loaders

### DIFF
--- a/src/Dynamic/binary-search.php
+++ b/src/Dynamic/binary-search.php
@@ -5,7 +5,7 @@
  * @package DynaMo
  */
 
-namespace WP_Syntex\DynaMo;
+namespace WP_Syntex\DynaMo\Dynamic;
 
 /**
  * Implements the search algorithm using a binary search, useful when no hash table is provided.

--- a/src/Dynamic/hash-search.php
+++ b/src/Dynamic/hash-search.php
@@ -5,7 +5,7 @@
  * @package DynaMo
  */
 
-namespace WP_Syntex\DynaMo;
+namespace WP_Syntex\DynaMo\Dynamic;
 
 /**
  * Implements the search algorithm using the hash table which should be a bit faster

--- a/src/Dynamic/mo-reader.php
+++ b/src/Dynamic/mo-reader.php
@@ -5,7 +5,7 @@
  * @package DynaMo
  */
 
-namespace WP_Syntex\DynaMo;
+namespace WP_Syntex\DynaMo\Dynamic;
 
 /**
  * A class to read MO files.

--- a/src/Dynamic/mo-reader.php
+++ b/src/Dynamic/mo-reader.php
@@ -12,7 +12,7 @@ namespace WP_Syntex\DynaMo\Dynamic;
  *
  * @since 1.0
  */
-class MO_Reader {
+class MO_Reader extends \WP_Syntex\DynaMo\MO_Reader {
 
 	/**
 	 * The object handling the translations search algorithm.
@@ -20,13 +20,6 @@ class MO_Reader {
 	 * @var Search_Handler
 	 */
 	protected $search_handler;
-
-	/**
-	 * The plural expression founded in the MO file.
-	 *
-	 * @var string
-	 */
-	protected $plural_expression;
 
 	/**
 	 * Parses the MO file.
@@ -53,19 +46,8 @@ class MO_Reader {
 			return false;
 		}
 
-		// Read and parse the header.
-		$header = fread( $handle, 24 );
-		if ( ! $header || $this->strlen( $header ) !== 24 ) {
-			return false;
-		}
-
-		$header = unpack( "{$endian}revision/{$endian}total/{$endian}originals_lengths_addr/{$endian}translations_lengths_addr/{$endian}hash_length/{$endian}hash_addr", $header );
-		if ( ! is_array( $header ) ) {
-			return false;
-		}
-
-		// Support revision 0 of MO format specs, only.
-		if ( 0 !== $header['revision'] ) {
+		$header = self::read_header( $handle, $endian );
+		if ( ! $header ) {
 			return false;
 		}
 
@@ -144,113 +126,5 @@ class MO_Reader {
 	 */
 	public function get_search_handler() {
 		return $this->search_handler;
-	}
-
-	/**
-	 * Returns the plural expression.
-	 *
-	 * @since 1.0
-	 *
-	 * @return string
-	 */
-	public function get_plural_expression() {
-		return $this->plural_expression;
-	}
-
-	/**
-	 * Returns the unpack format for the endianness of the file.
-	 *
-	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/mo.php#L192-L211
-	 *
-	 * @since 1.0
-	 *
-	 * @param string $magic Magic read from the file.
-	 * @return string|false
-	 */
-	protected static function get_byteorder( $magic ) {
-		$magic = unpack( 'V', $magic );
-		if ( ! $magic ) {
-			return false;
-		}
-
-		$magic = reset( $magic );
-
-		// Little endian, second case for 32 bits.
-		if ( 0x950412de === $magic || ( PHP_INT_SIZE === 4 && -1794895138 === $magic ) ) {
-			return 'V';
-		}
-
-		// Big endian, second case for 32 bits.
-		if ( 0xde120495 === $magic || ( PHP_INT_SIZE === 4 && -569244523 === $magic ) ) {
-			return 'N';
-		}
-
-		return false;
-	}
-
-	/**
-	 * Reads and unpacks a table of integers, typically used to read the tables
-	 * for original strings table, translations table and hashes table.
-	 *
-	 * @since 1.0
-	 *
-	 * @param resource $handle Stream handle.
-	 * @param string   $endian 'N' or 'V' depending on the endianness of the file.
-	 * @param int      $length The number of values to read.
-	 * @return int[]|false
-	 */
-	protected static function read_and_unpack( $handle, $endian, $length ) {
-		$strings = fread( $handle, $length * 4 );
-		if ( ! $strings || self::strlen( $strings ) !== $length * 4 ) {
-			return false;
-		}
-
-		return unpack( $endian . $length, $strings );
-	}
-
-	/**
-	 * Returns the length of a string.
-	 *
-	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/streams.php#L99-L109
-	 *
-	 * @since 1.0
-	 *
-	 * @param string $string The string.
-	 * @return int
-	 */
-	protected static function strlen( $string ) {
-		if ( function_exists( 'mb_strlen' ) && ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
-			return mb_strlen( $string, 'ascii' );
-		} else {
-			return strlen( $string );
-		}
-	}
-
-	/**
-	 * Sets the plural expression from the translations headers.
-	 *
-	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/translations.php#L265-L295
-	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/translations.php#L202-L214
-	 *
-	 * @since 1.0
-	 *
-	 * @param string $headers Translations headers read from the MO file.
-	 * @return string
-	 */
-	protected function parse_plural_forms_expression( $headers ) {
-		// Sometimes \n's are used instead of real new lines.
-		$headers = str_replace( '\n', "\n", $headers );
-		$lines   = explode( "\n", $headers );
-
-		foreach ( $lines as $line ) {
-			if ( false !== strpos( $line, 'Plural-Forms' ) ) {
-				$parts = explode( ':', $line, 2 );
-				if ( preg_match( '/^\s*nplurals\s*=\s*(\d+)\s*;\s+plural\s*=\s*(.+)$/', $parts[1], $matches ) ) {
-					return rtrim( trim( $matches[2] ), ';' );
-				}
-			}
-		}
-
-		return 'n != 1'; // The default value (en_US).
 	}
 }

--- a/src/Dynamic/mo.php
+++ b/src/Dynamic/mo.php
@@ -5,7 +5,7 @@
  * @package DynaMo
  */
 
-namespace WP_Syntex\DynaMo;
+namespace WP_Syntex\DynaMo\Dynamic;
 
 /**
  * A class defining objects usable in the WordPress global $l10n array.

--- a/src/Dynamic/mo.php
+++ b/src/Dynamic/mo.php
@@ -12,17 +12,7 @@ namespace WP_Syntex\DynaMo\Dynamic;
  *
  * @since 1.0
  */
-class MO {
-
-	/**
-	 * Empty array.
-	 *
-	 * It is there only in case someone attempts to directly merge an instance
-	 * of this class into a WordPress MO object.
-	 *
-	 * @var \Translation_Entry[]
-	 */
-	public $entries = array();
+class MO extends \WP_Syntex\DynaMo\MO {
 
 	/**
 	 * Stores all translations for (maybe) next calls.

--- a/src/Dynamic/search-handler.php
+++ b/src/Dynamic/search-handler.php
@@ -5,7 +5,7 @@
  * @package DynaMo
  */
 
-namespace WP_Syntex\DynaMo;
+namespace WP_Syntex\DynaMo\Dynamic;
 
 /**
  * Interface for algorithms to search translations in a MO file.

--- a/src/mo-reader.php
+++ b/src/mo-reader.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * MO_Reader abstract class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * An abstract class helping to read MO files.
+ *
+ * @since 1.1
+ */
+abstract class MO_Reader {
+
+	/**
+	 * The plural expression founded in the MO file.
+	 *
+	 * @var string
+	 */
+	protected $plural_expression;
+
+	/**
+	 * Parses the MO file.
+	 *
+	 * @since 1.0
+	 *
+	 * @param resource $handle Stream handle.
+	 * @return bool True if successful, false otherwise.
+	 */
+	abstract public function parse( $handle );
+
+	/**
+	 * Returns the plural expression.
+	 *
+	 * @since 1.0
+	 *
+	 * @return string
+	 */
+	public function get_plural_expression() {
+		return $this->plural_expression;
+	}
+
+	/**
+	 * Returns the unpack format for the endianness of the file.
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/mo.php#L192-L211
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $magic Magic read from the file.
+	 * @return string|false
+	 */
+	protected static function get_byteorder( $magic ) {
+		$magic = unpack( 'V', $magic );
+		if ( ! $magic ) {
+			return false;
+		}
+
+		$magic = reset( $magic );
+
+		// Little endian, second case for 32 bits.
+		if ( 0x950412de === $magic || ( PHP_INT_SIZE === 4 && -1794895138 === $magic ) ) {
+			return 'V';
+		}
+
+		// Big endian, second case for 32 bits.
+		if ( 0xde120495 === $magic || ( PHP_INT_SIZE === 4 && -569244523 === $magic ) ) {
+			return 'N';
+		}
+
+		return false;
+	}
+
+	/**
+	 * Reads and parses the header.
+	 *
+	 * @since 1.1
+	 *
+	 * @param resource $handle Stream handle.
+	 * @param string   $endian 'N' or 'V' depending on the endianness of the file.
+	 * @return array|false
+	 */
+	protected static function read_header( $handle, $endian ) {
+		$header = fread( $handle, 24 );
+		if ( ! $header || self::strlen( $header ) !== 24 ) {
+			return false;
+		}
+
+		$header = unpack( "{$endian}revision/{$endian}total/{$endian}originals_lengths_addr/{$endian}translations_lengths_addr/{$endian}hash_length/{$endian}hash_addr", $header );
+		if ( ! is_array( $header ) ) {
+			return false;
+		}
+
+		// Support revision 0 of MO format specs, only.
+		if ( 0 !== $header['revision'] ) {
+			return false;
+		}
+
+		return $header;
+	}
+
+	/**
+	 * Reads and unpacks a table of integers, typically used to read the tables
+	 * for original strings table, translations table and hashes table.
+	 *
+	 * @since 1.0
+	 *
+	 * @param resource $handle Stream handle.
+	 * @param string   $endian 'N' or 'V' depending on the endianness of the file.
+	 * @param int      $length The number of values to read.
+	 * @return int[]|false
+	 */
+	protected static function read_and_unpack( $handle, $endian, $length ) {
+		$strings = fread( $handle, $length * 4 );
+		if ( ! $strings || self::strlen( $strings ) !== $length * 4 ) {
+			return false;
+		}
+
+		return unpack( $endian . $length, $strings );
+	}
+
+	/**
+	 * Returns the length of a string.
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/streams.php#L99-L109
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $string The string.
+	 * @return int
+	 */
+	protected static function strlen( $string ) {
+		if ( function_exists( 'mb_strlen' ) && ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
+			return mb_strlen( $string, 'ascii' );
+		} else {
+			return strlen( $string );
+		}
+	}
+
+	/**
+	 * Sets the plural expression from the translations headers.
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/translations.php#L265-L295
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/translations.php#L202-L214
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $headers Translations headers read from the MO file.
+	 * @return string
+	 */
+	protected function parse_plural_forms_expression( $headers ) {
+		// Sometimes \n's are used instead of real new lines.
+		$headers = str_replace( '\n', "\n", $headers );
+		$lines   = explode( "\n", $headers );
+
+		foreach ( $lines as $line ) {
+			if ( false !== strpos( $line, 'Plural-Forms' ) ) {
+				$parts = explode( ':', $line, 2 );
+				if ( preg_match( '/^\s*nplurals\s*=\s*(\d+)\s*;\s+plural\s*=\s*(.+)$/', $parts[1], $matches ) ) {
+					return rtrim( trim( $matches[2] ), ';' );
+				}
+			}
+		}
+
+		return 'n != 1'; // The default value (en_US).
+	}
+}

--- a/src/mo.php
+++ b/src/mo.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * MO abstract Class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo;
+
+/**
+ * An abstract class defining the interface for objects usable in the WordPress global $l10n array.
+ *
+ * This is an abstract class and not an interface due to WordPress accessing directly the public property.
+ *
+ * @since 1.1
+ */
+abstract class MO {
+
+	/**
+	 * Empty array.
+	 *
+	 * It is there only in case someone attempts to directly merge an instance
+	 * of this class into a WordPress MO object.
+	 *
+	 * @var \Translation_Entry[]
+	 */
+	public $entries = array();
+
+	/**
+	 * Imports a MO file.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string $filename Path to the MO file.
+	 * @return bool
+	 */
+	abstract public function import_from_file( $filename );
+
+	/**
+	 * Merges an existing MO file into this one.
+	 *
+	 * @since 1.1
+	 *
+	 * @param MO $other Other instance to merge to the current instance.
+	 * @return void
+	 */
+	abstract public function merge_with( &$other );
+
+	/**
+	 * Retrieves translated string with gettext context.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string      $singular Text to translate.
+	 * @param string|null $context  Context information for the translators.
+	 * @return string
+	 */
+	abstract public function translate( $singular, $context = null );
+
+	/**
+	 * Translates and retrieves the singular or plural form based on the supplied number, with gettext context.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string      $singular The text to be used if the number is singular.
+	 * @param string      $plural   The text to be used if the number is plural.
+	 * @param int         $count    The number to compare against to use either the singular or plural form.
+	 * @param string|null $context  Context information for the translators.
+	 * @return string
+	 */
+	abstract public function translate_plural( $singular, $plural, $count, $context = null );
+}

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -41,7 +41,7 @@ class Plugin {
 			return false;
 		}
 
-		$mo = new MO();
+		$mo = new Dynamic\MO();
 		if ( ! $mo->import_from_file( $mofile ) ) {
 			return false;
 		}

--- a/tests/phpunit/tests/test-mo.php
+++ b/tests/phpunit/tests/test-mo.php
@@ -15,7 +15,7 @@ class MO_Test extends WP_UnitTestCase {
 	public function test_instance() {
 		( new Plugin() )->add_hooks();
 		load_textdomain( 'domain', TEST_DATA_DIR . 'some_translations.mo' );
-		$this->assertTrue( $GLOBALS['l10n']['domain'] instanceof WP_Syntex\DynaMo\MO );
+		$this->assertTrue( $GLOBALS['l10n']['domain'] instanceof WP_Syntex\DynaMo\Dynamic\MO );
 	}
 
 	public function test_loading_two_files_should_include_strings_of_both_files() {
@@ -40,10 +40,10 @@ class MO_Test extends WP_UnitTestCase {
 	}
 
 	public function test_merge_should_keep_other_strings() {
-		$mo = new WP_Syntex\DynaMo\MO();
+		$mo = new WP_Syntex\DynaMo\Dynamic\MO();
 		$mo->import_from_file( TEST_DATA_DIR . 'alternative.mo' );
 
-		$other = new WP_Syntex\DynaMo\MO();
+		$other = new WP_Syntex\DynaMo\Dynamic\MO();
 		$other->import_from_file( TEST_DATA_DIR . 'automatic.mo' );
 
 		$mo->merge_with( $other );
@@ -56,7 +56,7 @@ class MO_Test extends WP_UnitTestCase {
 	 */
 	public function test_merge_into_WP_MO() {
 		$wp_mo  = new \MO();
-		$our_mo = new WP_Syntex\DynaMo\MO();
+		$our_mo = new WP_Syntex\DynaMo\Dynamic\MO();
 
 		$wp_mo->merge_with( $our_mo );
 		$this->assertTrue( $wp_mo instanceof \MO );
@@ -86,6 +86,6 @@ class MO_Test extends WP_UnitTestCase {
 		$this->assertFalse( is_textdomain_loaded( 'internationalized-plugin' ) );
 		$this->assertSame( 'Das ist ein Dummy Plugin', i18n_plugin_test() );
 		$this->assertTrue( is_textdomain_loaded( 'internationalized-plugin' ) );
-		$this->assertTrue( $GLOBALS['l10n']['internationalized-plugin'] instanceof WP_Syntex\DynaMo\MO );
+		$this->assertTrue( $GLOBALS['l10n']['internationalized-plugin'] instanceof WP_Syntex\DynaMo\Dynamic\MO );
 	}
 }


### PR DESCRIPTION
- The current loader is moved to the subdirectory (and namespace) `Dynamic`.
- Part of the `MO_Reader` class is moved to an abstract which can be extended for other readers.
- A new `MO` abstract class is created. This is in fact an interface including a public property used by WordPress. It si meant to be extended by all `MO` classes from loaders. 