### PR TITLE
Add object cache support

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,4 +5,5 @@ parameters:
 	paths:
 		- dynamo.php
 		- src/
-	checkMissingIterableValueType: false
+	ignoreErrors:
+		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'

--- a/src/Dynamic/mo.php
+++ b/src/Dynamic/mo.php
@@ -48,6 +48,10 @@ class MO extends \WP_Syntex\DynaMo\MO {
 	 * @return bool
 	 */
 	public function import_from_file( $filename ) {
+		if ( ! is_readable( $filename ) ) {
+			return false;
+		}
+
 		$file_handle = fopen( $filename, 'rb' );
 		$mem_handle  = fopen( 'php://memory', 'w+b' );
 

--- a/src/Full/mo-reader.php
+++ b/src/Full/mo-reader.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * MO_Reader class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo\Full;
+
+/**
+ * A class to read MO files.
+ *
+ * @since 1.1
+ */
+class MO_Reader extends \WP_Syntex\DynaMo\MO_Reader {
+
+	/**
+	 * The array of translations.
+	 *
+	 * @var string[]
+	 */
+	protected $translations;
+
+	/**
+	 * Parses the MO file.
+	 *
+	 * @see https://www.gnu.org/software/gettext/manual/gettext.html#MO-Files
+	 * @see https://github.com/WordPress/WordPress/blob/5.8.2/wp-includes/pomo/mo.php#L213-L301
+	 *
+	 * @since 1.1
+	 *
+	 * @param resource $handle Stream handle.
+	 * @return bool True if successful, false otherwise.
+	 */
+	public function parse( $handle ) {
+		rewind( $handle );
+
+		// Read the magic number and get the endianness of the file.
+		$magic = fread( $handle, 4 );
+		if ( ! $magic ) {
+			return false;
+		}
+
+		$endian = self::get_byteorder( $magic );
+		if ( false === $endian ) {
+			return false;
+		}
+
+		$header = self::read_header( $handle, $endian );
+		if ( ! $header ) {
+			return false;
+		}
+
+		// Seek to data blocks.
+		fseek( $handle, $header['originals_lengths_addr'] );
+
+		// Read originals' indices.
+		$originals_lengths_length = $header['translations_lengths_addr'] - $header['originals_lengths_addr'];
+		if ( $originals_lengths_length !== $header['total'] * 8 ) {
+			return false;
+		}
+
+		$originals = self::read_and_unpack( $handle, $endian, $header['total'] * 2 );
+		if ( ! $originals ) {
+			return false;
+		}
+
+		// Read translations' indices.
+		$translations_lengths_length = $header['hash_addr'] - $header['translations_lengths_addr'];
+		if ( $translations_lengths_length !== $header['total'] * 8 ) {
+			return false;
+		}
+
+		$translations = self::read_and_unpack( $handle, $endian, $header['total'] * 2 );
+		if ( ! $translations ) {
+			return false;
+		}
+
+		$o = array();
+
+		for ( $i = 0; $i < $header['total']; $i++ ) {
+			if ( $originals[ 2 * $i + 1 ] > 0 ) {
+				\fseek( $handle, (int) $originals[ 2 * $i + 2 ] );
+				$original = (string) \fread( $handle, (int) $originals[ 2 * $i + 1 ] );
+				$parts    = explode( "\0", $original ); // Remove the plural forms.
+				$o[ $i ]  = $parts[0];
+			} else {
+				$o[ $i ] = '';
+			}
+		}
+
+		for ( $i = 0; $i < $header['total']; $i++ ) {
+			\fseek( $handle, (int) $translations[ 2 * $i + 2 ] );
+			$translation = (string) \fread( $handle, (int) $translations[ 2 * $i + 1 ] );
+			if ( '' === $o[ $i ] ) {
+				$this->plural_expression = $this->parse_plural_forms_expression( $translation );
+			} else {
+				$this->translations[ $o[ $i ] ] = $translation;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the array of translations.
+	 *
+	 * @since 1.1
+	 *
+	 * @return string[]
+	 */
+	public function get_translations() {
+		return $this->translations;
+	}
+}

--- a/src/Full/mo.php
+++ b/src/Full/mo.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * MO Class
+ *
+ * @package DynaMo
+ */
+
+namespace WP_Syntex\DynaMo\Full;
+
+/**
+ * A class defining objects usable in the WordPress global $l10n array.
+ *
+ * @since 1.1
+ */
+class MO extends \WP_Syntex\DynaMo\MO {
+
+	/**
+	 * Stores all translations for (maybe) next calls.
+	 *
+	 * @var string[]
+	 */
+	protected $container = array();
+
+	/**
+	 * An instance of the WordPress Plural_Forms class.
+	 *
+	 * @var \Plural_Forms
+	 */
+	protected $plural_forms;
+
+	/**
+	 * Imports a MO file.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string $filename Path to the MO file.
+	 * @return bool
+	 */
+	public function import_from_file( $filename ) {
+		$file_handle = fopen( $filename, 'rb' );
+
+		if ( ! $file_handle ) {
+			return false;
+		}
+
+		$reader = new MO_Reader();
+		$parsed = $reader->parse( $file_handle );
+		fclose( $file_handle );
+
+		if ( ! $parsed ) {
+			return false;
+		}
+
+		$this->plural_forms = new \Plural_Forms( $reader->get_plural_expression() );
+		$this->container    = $reader->get_translations();
+		return true;
+	}
+
+	/**
+	 * Merges an existing MO file into this one.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * @since 1.1
+	 *
+	 * @param MO $other Other instance to merge to the current instance.
+	 * @return void
+	 */
+	public function merge_with( &$other ) {
+		if ( $other instanceof MO ) {
+			$this->container = array_merge( $this->container, $other->container );
+		}
+	}
+
+	/**
+	 * Retrieves translated string with gettext context.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string      $singular Text to translate.
+	 * @param string|null $context  Context information for the translators.
+	 * @return string
+	 */
+	public function translate( $singular, $context = null ) {
+		// _get_plugin_data_markup_translate() may call translate() with an empty string.
+		if ( empty( $singular ) ) {
+			return $singular;
+		}
+
+		$key = ! $context ? $singular : $context . "\4" . $singular;
+
+		if ( isset( $this->container[ $key ] ) ) {
+			return $this->container[ $key ];
+		}
+
+		return $singular;
+	}
+
+	/**
+	 * Translates and retrieves the singular or plural form based on the supplied number, with gettext context.
+	 * Required by the implicit WordPress interface.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string      $singular The text to be used if the number is singular.
+	 * @param string      $plural   The text to be used if the number is plural.
+	 * @param int         $count    The number to compare against to use either the singular or plural form.
+	 * @param string|null $context  Context information for the translators.
+	 * @return string
+	 */
+	public function translate_plural( $singular, $plural, $count, $context = null ) {
+		$key = ! $context ? $singular : $context . "\4" . $singular;
+
+		if ( isset( $this->container[ $key ] ) ) {
+			$translations = explode( "\0", $this->container[ $key ] );
+			$index        = $this->plural_forms->get( $count );
+			if ( isset( $translations[ $index ] ) ) {
+				return $translations[ $index ];
+			}
+		}
+
+		return 1 === (int) $count ? $singular : $plural;
+	}
+}

--- a/src/Full/mo.php
+++ b/src/Full/mo.php
@@ -72,6 +72,10 @@ class MO extends \WP_Syntex\DynaMo\MO {
 			}
 		}
 
+		if ( ! is_readable( $filename ) ) {
+			return false;
+		}
+
 		// Read and parse the translation file.
 		$file_handle = fopen( $filename, 'rb' );
 

--- a/src/Full/mo.php
+++ b/src/Full/mo.php
@@ -61,6 +61,8 @@ class MO extends \WP_Syntex\DynaMo\MO {
 		if ( $using_ext_cache ) {
 			add_action( 'upgrader_process_complete', array( __CLASS__, 'clean_cache' ) ); // Cleans the cache each time there is an update.
 
+			wp_cache_add_global_groups( self::CACHE_GROUP ); // The cache is common to all sites on multisite.
+
 			$last_changed = wp_cache_get_last_changed( self::CACHE_GROUP );
 			$key          = md5( $filename ) . ":$last_changed";
 			$cache        = wp_cache_get( $key, self::CACHE_GROUP );

--- a/src/mo-reader.php
+++ b/src/mo-reader.php
@@ -80,7 +80,7 @@ abstract class MO_Reader {
 	 *
 	 * @param resource $handle Stream handle.
 	 * @param string   $endian 'N' or 'V' depending on the endianness of the file.
-	 * @return array|false
+	 * @return int[]|false
 	 */
 	protected static function read_header( $handle, $endian ) {
 		$header = fread( $handle, 24 );

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -41,7 +41,18 @@ class Plugin {
 			return false;
 		}
 
-		$mo = new Dynamic\MO();
+		$mo = wp_using_ext_object_cache() ? new Full\MO() : new Dynamic\MO();
+
+		/**
+		 * Filters the object used to load the translation file.
+		 *
+		 * @since 1.1
+		 *
+		 * @param object $mo     MO file loader.
+		 * @param string $domain Text domain.
+		 */
+		$mo = apply_filters( 'dynamo_file_loader', $mo, $domain );
+
 		if ( ! $mo->import_from_file( $mofile ) ) {
 			return false;
 		}

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -48,7 +48,7 @@ class Plugin {
 		 *
 		 * @since 1.1
 		 *
-		 * @param object $mo     MO file loader.
+		 * @param MO     $mo     MO file loader.
 		 * @param string $domain Text domain.
 		 */
 		$mo = apply_filters( 'dynamo_file_loader', $mo, $domain );

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -37,10 +37,6 @@ class Plugin {
 	public function override_load_textdomain( $override, $domain, $mofile ) {
 		global $l10n;
 
-		if ( ! is_readable( $mofile ) ) {
-			return false;
-		}
-
 		$mo = wp_using_ext_object_cache() ? new Full\MO() : new Dynamic\MO();
 
 		/**

--- a/tests/phpunit/tests/test-external-cache.php
+++ b/tests/phpunit/tests/test-external-cache.php
@@ -1,0 +1,56 @@
+<?php
+
+use WP_Syntex\DynaMo\Plugin as Plugin;
+
+class External_Cache_Test extends WP_UnitTestCase {
+
+	const CACHE_GROUP = 'DynaMo';
+
+	const LAST_CHANGED = 1;
+
+	public function set_up() {
+		$this->using_ext_cache = wp_using_ext_object_cache();
+		wp_using_ext_object_cache( true ); // Fake external object cache.
+		wp_cache_set( 'last_changed', self::LAST_CHANGED, self::CACHE_GROUP );
+	}
+
+	public function tear_down() {
+		wp_using_ext_object_cache( $this->using_ext_cache );
+		wp_cache_delete( 'last_changed', self::CACHE_GROUP );
+
+		unset( $GLOBALS['l10n'] );
+	}
+
+	public function test_read_translations_from_cache() {
+		$last_changed = wp_cache_get_last_changed( self::CACHE_GROUP );
+		$key          = md5( 'some_translations.mo' ) . ':' . self::LAST_CHANGED;
+		$to_cache     = array(
+			'plural_forms' => 'n > 1',
+			'translations' => array(
+				'She let the balloon float up into the air with her hopes and dreams.' => 'Elle a laissé le ballon flotter dans les airs avec ses espoirs et ses rêves.',
+			),
+		);
+		wp_cache_set( $key, $to_cache, self::CACHE_GROUP );
+
+		( new Plugin() )->add_hooks();
+		load_textdomain( 'default', 'some_translations.mo' );
+
+		$this->assertSame( 'Elle a laissé le ballon flotter dans les airs avec ses espoirs et ses rêves.', __( 'She let the balloon float up into the air with her hopes and dreams.' ) );
+	}
+
+	public function test_write_translations_to_cache() {
+		$filename = TEST_DATA_DIR . 'some_translations.mo';
+
+		( new Plugin() )->add_hooks();
+		load_textdomain( 'default', $filename );
+
+		$key   = md5( $filename ) . ':' . self::LAST_CHANGED;
+		$cache = wp_cache_get( $key, self::CACHE_GROUP );
+
+		$this->assertCount( 2, $cache );
+		$this->assertArrayHasKey( 'plural_forms', $cache );
+		$this->assertIsString( $cache['plural_forms'] );
+		$this->assertArrayHasKey( 'translations', $cache );
+		$this->assertCount( 4, $cache['translations'] ); // The number of translations in this .mo file.
+	}
+}

--- a/tests/phpunit/tests/test-mo.php
+++ b/tests/phpunit/tests/test-mo.php
@@ -9,17 +9,41 @@ class MO_Test extends WP_UnitTestCase {
 		remove_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 	}
 
-	/**
-	 * Make sure load_textdomain() loads our class.
-	 */
-	public function test_instance() {
-		( new Plugin() )->add_hooks();
-		load_textdomain( 'domain', TEST_DATA_DIR . 'some_translations.mo' );
-		$this->assertTrue( $GLOBALS['l10n']['domain'] instanceof WP_Syntex\DynaMo\Dynamic\MO );
+	public function mo_provider() {
+		return array(
+			array( 'WP_Syntex\DynaMo\Dynamic\MO' ),
+			array( 'WP_Syntex\DynaMo\Full\MO' ),
+		);
 	}
 
-	public function test_loading_two_files_should_include_strings_of_both_files() {
+	protected function init( $class ) {
+		add_filter(
+			'dynamo_file_loader',
+			function() use ( $class ) {
+				return new $class();
+			}
+		);
 		( new Plugin() )->add_hooks();
+	}
+
+	/**
+	 * Make sure load_textdomain() loads our class.
+	 *
+	 * @dataProvider mo_provider
+	 */
+	public function test_instance( $class ) {
+		$this->init( $class );
+		load_textdomain( 'domain', TEST_DATA_DIR . 'some_translations.mo' );
+		$this->assertTrue( $GLOBALS['l10n']['domain'] instanceof $class );
+	}
+
+	/**
+	 * Test loading two files for same domain with different strings.
+	 *
+	 * @dataProvider mo_provider
+	 */
+	public function test_loading_two_files_should_include_strings_of_both_files( $class ) {
+		$this->init( $class );
 		load_textdomain( 'default', TEST_DATA_DIR . 'automatic.mo' );
 		load_textdomain( 'default', TEST_DATA_DIR . 'some_translations.mo' );
 
@@ -30,8 +54,13 @@ class MO_Test extends WP_UnitTestCase {
 		$this->assertSame( 'Les fourmis ont plus apprécié le barbecue que la famille.', __( 'The ants enjoyed the barbecue more than the family.' ) );
 	}
 
-	public function test_loading_two_files_should_not_overwrite_first_strings() {
-		( new Plugin() )->add_hooks();
+	/**
+	 * Test loading two files for same domain with same strings.
+	 *
+	 * @dataProvider mo_provider
+	 */
+	public function test_loading_two_files_should_not_overwrite_first_strings( $class ) {
+		$this->init( $class );
 		load_textdomain( 'default', TEST_DATA_DIR . 'alternative.mo' );
 		load_textdomain( 'default', TEST_DATA_DIR . 'automatic.mo' );
 
@@ -39,11 +68,16 @@ class MO_Test extends WP_UnitTestCase {
 		$this->assertSame( 'En regardant par la fenêtre, il vit un clown passer.', __( 'As he looked out the window, he saw a clown walk by.' ) );
 	}
 
-	public function test_merge_should_keep_other_strings() {
-		$mo = new WP_Syntex\DynaMo\Dynamic\MO();
+	/**
+	 * Test merging two files.
+	 *
+	 * @dataProvider mo_provider
+	 */
+	public function test_merge_should_keep_other_strings( $class ) {
+		$mo = new $class();
 		$mo->import_from_file( TEST_DATA_DIR . 'alternative.mo' );
 
-		$other = new WP_Syntex\DynaMo\Dynamic\MO();
+		$other = new $class();
 		$other->import_from_file( TEST_DATA_DIR . 'automatic.mo' );
 
 		$mo->merge_with( $other );
@@ -53,11 +87,12 @@ class MO_Test extends WP_UnitTestCase {
 
 	/**
 	 * Just test that we don't have any error.
+	 *
+	 * @dataProvider mo_provider
 	 */
-	public function test_merge_into_WP_MO() {
+	public function test_merge_into_WP_MO( $class ) {
 		$wp_mo  = new \MO();
-		$our_mo = new WP_Syntex\DynaMo\Dynamic\MO();
-
+		$our_mo = new $class();
 		$wp_mo->merge_with( $our_mo );
 		$this->assertTrue( $wp_mo instanceof \MO );
 	}
@@ -75,9 +110,11 @@ class MO_Test extends WP_UnitTestCase {
 	 * The test is directly inspired from a WordPress test
 	 *
 	 * @see https://github.com/WordPress/wordpress-develop/blob/5.8.2/tests/phpunit/tests/l10n/loadTextdomainJustInTime.php#L63-L80
+	 *
+	 * @dataProvider mo_provider
 	 */
-	public function test_load_just_in_time() {
-		( new Plugin() )->add_hooks();
+	public function test_load_just_in_time( $class ) {
+		$this->init( $class );
 
 		add_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 
@@ -86,6 +123,6 @@ class MO_Test extends WP_UnitTestCase {
 		$this->assertFalse( is_textdomain_loaded( 'internationalized-plugin' ) );
 		$this->assertSame( 'Das ist ein Dummy Plugin', i18n_plugin_test() );
 		$this->assertTrue( is_textdomain_loaded( 'internationalized-plugin' ) );
-		$this->assertTrue( $GLOBALS['l10n']['internationalized-plugin'] instanceof WP_Syntex\DynaMo\Dynamic\MO );
+		$this->assertTrue( $GLOBALS['l10n']['internationalized-plugin'] instanceof $class );
 	}
 }

--- a/tests/phpunit/tests/test-mo.php
+++ b/tests/phpunit/tests/test-mo.php
@@ -38,6 +38,17 @@ class MO_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test to read a wrong file.
+	 *
+	 * @dataProvider mo_provider
+	 */
+	public function test_unreadable_file( $class ) {
+		$this->init( $class );
+		load_textdomain( 'domain', 'some_unreadable_file.mo' );
+		$this->assertEmpty( $GLOBALS['l10n'] );
+	}
+
+	/**
 	 * Test loading two files for same domain with different strings.
 	 *
 	 * @dataProvider mo_provider

--- a/tests/phpunit/tests/test-specific.php
+++ b/tests/phpunit/tests/test-specific.php
@@ -11,8 +11,31 @@ class Specific_Test extends WP_UnitTestCase {
 		unset( $GLOBALS['l10n'] );
 	}
 
-	public function test_shipment_tracking() {
+	public function mo_provider() {
+		return array(
+			array( 'WP_Syntex\DynaMo\Dynamic\MO' ),
+			array( 'WP_Syntex\DynaMo\Full\MO' ),
+		);
+	}
+
+	protected function init( $class ) {
+		add_filter(
+			'dynamo_file_loader',
+			function() use ( $class ) {
+				return new $class();
+			}
+		);
 		( new Plugin() )->add_hooks();
+	}
+
+	/**
+	 * Test a WC Shipment tracking translation file which generated a notice
+	 * during the development of the inital version.
+	 *
+	 * @dataProvider mo_provider
+	 */
+	public function test_shipment_tracking( $class ) {
+		$this->init( $class );
 		load_textdomain( 'shipment-tracking', TEST_DATA_DIR . 'woocommerce-shipment-tracking-fr_FR.mo' );
 
 		// Call done by _get_plugin_data_markup_translate().

--- a/tests/phpunit/tests/test-translations-binary-search.php
+++ b/tests/phpunit/tests/test-translations-binary-search.php
@@ -8,6 +8,12 @@ class Translations_Binary_Search_Test extends WP_UnitTestCase {
 	use Translations_Test_Trait;
 
 	public function set_up() {
+		add_filter(
+			'dynamo_file_loader',
+			function() {
+				return new \WP_Syntex\DynaMo\Dynamic\MO();
+			}
+		);
 		( new Plugin() )->add_hooks();
 		load_textdomain( 'default', TEST_DATA_DIR . 'sl_SI_without_hash_table.mo' );
 	}

--- a/tests/phpunit/tests/test-translations-full-load.php
+++ b/tests/phpunit/tests/test-translations-full-load.php
@@ -4,18 +4,18 @@ require_once __DIR__ . '/translations-test-trait.php';
 
 use WP_Syntex\DynaMo\Plugin as Plugin;
 
-class Translations_Hash_Search_Test extends WP_UnitTestCase {
+class Translations_Full_Load_Test extends WP_UnitTestCase {
 	use Translations_Test_Trait;
 
 	public function set_up() {
 		add_filter(
 			'dynamo_file_loader',
 			function() {
-				return new \WP_Syntex\DynaMo\Dynamic\MO();
+				return new \WP_Syntex\DynaMo\Full\MO();
 			}
 		);
 		( new Plugin() )->add_hooks();
-		load_textdomain( 'default', TEST_DATA_DIR . 'sl_SI_with_hash_table.mo' );
+		load_textdomain( 'default', TEST_DATA_DIR . 'sl_SI_without_hash_table.mo' );
 	}
 }
 


### PR DESCRIPTION
This PR adds a new way to load MO files. As in WordPress, all translations of a given file are loaded in memory. However they are stored in an array of strings rather than an array of `Translation_Entry` objects. Thus, the performance is improved both when reading the file (it's faster to store a string in an array rather than creating a `Translation_Entry` object) and when translating strings.

Although this new method is faster than the method used in WordPress, processing the complete file is still slower than the dynamic method in use in v1.0. It becomes very fast if we don't have to read and parse the translation file. That's why, by default, the method is activated only when an external object cache is available.  

The method can be programmatically selected with the filter `dynamo_file_loader`.

The cache expiration limit is set to 12 hours by default and is programmatically filterable with the filter `dynamo_cache_expire`. In any case, the cache is cleaned at each update (WordPress, theme, plugins or language packs).

The cache is common to all sites for multisite.

As a side effect of this development, the check for file readabibility has been moved to the MO classes.