### PR TITLE
Fix external cache test not properly cleaned up

### DIFF
--- a/tests/phpunit/tests/test-external-cache.php
+++ b/tests/phpunit/tests/test-external-cache.php
@@ -9,7 +9,7 @@ class External_Cache_Test extends WP_UnitTestCase {
 	const LAST_CHANGED = 1;
 
 	public function set_up() {
-		$this->using_ext_cache = wp_using_ext_object_cache();
+		$this->using_ext_cache = (bool) wp_using_ext_object_cache();
 		wp_using_ext_object_cache( true ); // Fake external object cache.
 		wp_cache_set( 'last_changed', self::LAST_CHANGED, self::CACHE_GROUP );
 	}


### PR DESCRIPTION
`wp_using_ext_object_cache()` may return null. If passed as parameter, the value is kept unchanged, so always true. This value is then kept for tests executed after `External_Cache_Test`.

Casting the return value to `bool` ensures that the value will be correctly reset in `tear_down()`.