### PR TITLE
Cache the empty string translation to avoid a test for every translations

### DIFF
--- a/src/Full/mo.php
+++ b/src/Full/mo.php
@@ -93,9 +93,10 @@ class MO extends \WP_Syntex\DynaMo\MO {
 			return false;
 		}
 
-		$plural_expression  = $reader->get_plural_expression();
-		$this->plural_forms = new \Plural_Forms( $plural_expression );
-		$this->container    = $reader->get_translations();
+		$plural_expression   = $reader->get_plural_expression();
+		$this->plural_forms  = new \Plural_Forms( $plural_expression );
+		$this->container     = $reader->get_translations();
+		$this->container[''] = ''; // _get_plugin_data_markup_translate() may call translate() with an empty string.
 
 		// It's useless to cache anything if external object cache is not available.
 		if ( $using_ext_cache ) {
@@ -150,11 +151,6 @@ class MO extends \WP_Syntex\DynaMo\MO {
 	 * @return string
 	 */
 	public function translate( $singular, $context = null ) {
-		// _get_plugin_data_markup_translate() may call translate() with an empty string.
-		if ( empty( $singular ) ) {
-			return $singular;
-		}
-
 		$key = ! $context ? $singular : $context . "\4" . $singular;
 
 		if ( isset( $this->container[ $key ] ) ) {

--- a/tests/phpunit/tests/test-external-cache.php
+++ b/tests/phpunit/tests/test-external-cache.php
@@ -51,6 +51,6 @@ class External_Cache_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'plural_forms', $cache );
 		$this->assertIsString( $cache['plural_forms'] );
 		$this->assertArrayHasKey( 'translations', $cache );
-		$this->assertCount( 4, $cache['translations'] ); // The number of translations in this .mo file.
+		$this->assertCount( 5, $cache['translations'] ); // The number of translations in this .mo file, including the empty string.
 	}
 }


### PR DESCRIPTION
When using external cache we used to check for an empty string for each `translate()` call. It should be more efficient to store the translation in the cache and avoid this test, as already done for dynamic translations.