### PR TITLE
Fix a conflict with WPML

### DIFF
--- a/src/Dynamic/mo.php
+++ b/src/Dynamic/mo.php
@@ -102,16 +102,19 @@ class MO extends \WP_Syntex\DynaMo\MO {
 	public function translate( $singular, $context = null ) {
 		$key = ! $context ? $singular : $context . "\4" . $singular;
 
-		if ( isset( $this->container[ $key ] ) ) {
-			return $this->container[ $key ];
+		if ( ! isset( $this->container[ $key ] ) ) {
+			foreach ( $this->items as $item ) {
+				$translation = $item->get_translation( $key );
+				if ( ! empty( $translation ) ) {
+					$this->container[ $key ] = $translation;
+					break;
+				}
+			}
 		}
 
-		foreach ( $this->items as $item ) {
-			$translation = $item->get_translation( $key );
-			if ( ! empty( $translation ) ) {
-				$this->container[ $key ] = $translation;
-				return $translation;
-			}
+		if ( isset( $this->container[ $key ] ) ) {
+			$parts = explode( "\0", $this->container[ $key ] );
+			return $parts[0];
 		}
 
 		$this->container[ $key ] = $singular; // Default in case we don't find a translation.

--- a/src/Full/mo.php
+++ b/src/Full/mo.php
@@ -154,7 +154,8 @@ class MO extends \WP_Syntex\DynaMo\MO {
 		$key = ! $context ? $singular : $context . "\4" . $singular;
 
 		if ( isset( $this->container[ $key ] ) ) {
-			return $this->container[ $key ];
+			$parts = explode( "\0", $this->container[ $key ] );
+			return $parts[0];
 		}
 
 		return $singular;


### PR DESCRIPTION
Fixes #13 

`WPML\ST\MO\Plural::handle_plural()` hooked to `ngettext`, translates the original singular and plural strings passed to `_n()` with `__()`.

This is rather unexpected and causes a warning when translating the singular form as in such case Dynamo returns something like `'translated singular' ."\0" . 'translated plural'` (with optionally more plural strings depending on the language). So in the example described in #13, the translated string has 2 or more `%s` which breaks `sprintf()` which expects only one.

Although using `__()` on a part of a plural string is rather unexpected, the MO implementation WordPress returns the translation of the singular form when `__()` is applied to the original singular form. We thus must do the same for a full backward compatibility.

* This PR adds tests with `_n()` called before and after `__()` to check the influence of the cache. Aside, we now also test the original MO class just to make sure that we reproduce the same behavior in our classes.
* The PR fixes the compatibility issue by always exploding the translation, even for singular translation, just in case the string passed to `__()` would be the singular form of a plural string.