### PR TITLE
Modify comments for PHPUnit tests of same string translated by __() and _n()

### DIFF
--- a/tests/phpunit/tests/test-translations.php
+++ b/tests/phpunit/tests/test-translations.php
@@ -197,9 +197,9 @@ class Translations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Although it should be wrong to translate the singular form of a plural string with __(),
-	 * WPML does and well... WordPress returns the correct value. So we should do it either.
-	 * Here, the wrong call to __() is made before the right call to _n() to test the impact of cache.
+	 * It's possible that a plugin translates the same (singular) string with __() and _n().
+	 * This doesn't break WordPress and is exploited at least in WPML and Query Monitor.
+	 * Here, the call to __() is made before the right call to _n() to test the impact of cache.
 	 *
 	 * @dataProvider data_provider
 	 *
@@ -213,9 +213,9 @@ class Translations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Although it should be wrong to translate the singular form of a plural string with __(),
-	 * WPML does and well... WordPress returns the correct value. So we should do it either.
-	 * Here, the wrong call to __() is made after the right call to _n() to test the impact of cache.
+	 * It's possible that a plugin translates the same (singular) string with __() and _n().
+	 * This doesn't break WordPress and is exploited at least in WPML and Query Monitor.
+	 * Here, the call to __() is made after the right call to _n() to test the impact of cache.
 	 *
 	 * @dataProvider data_provider
 	 *


### PR DESCRIPTION
In #15 we fixed an issue that we believed to be a confict with WPML.
In fact, nothing prevents a developer to pass the same string to `__()` and `_n()`. This is the case for example in Query Monitor where the we can find `__( '%s S' )` and `_n( '%s S', '%s S' )`.
The MO format is not able to distinguish the two cases as the key is always the singular for in a plural string. So only one translation is stored. Not sure if all softwares take care about this case. GlotPress seems to export the plural form.
Anyway, we need to change the comments which refer to a wrong usage in WPML.