### PR TITLE
PHPStan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,4 @@ parameters:
 		- dynamo.php
 		- src/
 	ignoreErrors:
-		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
+		- '#^Parameter \#2 \$length of function fread expects int<0, max>, int given\.$#'

--- a/src/Full/mo.php
+++ b/src/Full/mo.php
@@ -67,7 +67,7 @@ class MO extends \WP_Syntex\DynaMo\MO {
 			$key          = md5( $filename ) . ":$last_changed";
 			$cache        = wp_cache_get( $key, self::CACHE_GROUP );
 
-			if ( false !== $cache ) {
+			if ( is_array( $cache ) ) {
 				$this->container    = $cache['translations'];
 				$this->plural_forms = new \Plural_Forms( $cache['plural_forms'] );
 				return true;


### PR DESCRIPTION
- Ignore `Parameter #2 $length of function fread expects int<0, max>, int  given.` as it seems complec to fix with doc.
- Remove Ignored error pattern `#^Function apply_filters invoked with [34567] parameters, 2 required\.$#` after phpstan-wordpress update
- Fix access offset on mixed.