### PR TITLE
Ensure that $plural_expression is always a string

### DIFF
--- a/src/mo-reader.php
+++ b/src/mo-reader.php
@@ -19,7 +19,7 @@ abstract class MO_Reader {
 	 *
 	 * @var string
 	 */
-	protected $plural_expression;
+	protected $plural_expression = '';
 
 	/**
 	 * Parses the MO file.


### PR DESCRIPTION
Since #24, the plural expression may be undefined. This PR ensures that this is always a string (possibly empty) to avoid a [deprecated notice in PHP 8.1](https://app.travis-ci.com/github/polylang/dynamo/jobs/604896461).
```
PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /home/travis/build/polylang/dynamo/tmp/wordpress/wp-includes/pomo/plural-forms.php on line 101
``` 
