### PR TITLE
Let's test WP 6.2 and PHP 8.2 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ jobs:
       php: "7.2"
       env: "WP_VERSION=5.2 WP_MULTISITE=0"
 
-    - name: "WP 6.0 - PHP 5.6"
+    - name: "WP 6.2 - PHP 5.6"
       dist: "xenial"
       php: "5.6"
-      env: "WP_VERSION=6.0 WP_MULTISITE=0"
+      env: "WP_VERSION=6.2 WP_MULTISITE=0"
 
-    - name: "WP 6.0 - PHP 8.0"
+    - name: "WP 6.2 - PHP 8.0"
       php: "8.0"
-      env: "WP_VERSION=6.0 WP_MULTISITE=0"
+      env: "WP_VERSION=6.2 WP_MULTISITE=0"
 
     - name: "WP nightly - PHP 5.6"
       dist: "xenial"
@@ -38,8 +38,8 @@ jobs:
       php: "8.0"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
-    - name: "WP nightly - PHP 8.1"
-      php: "8.1"
+    - name: "WP nightly - PHP 8.2"
+      php: "8.2"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
   allow_failures:
@@ -50,7 +50,7 @@ jobs:
     - php: "8.0"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
-    - php: "8.1"
+    - php: "8.2"
       env: "WP_VERSION=nightly WP_MULTISITE=0"
 
 services:

--- a/tests/phpunit/tests/test-external-cache.php
+++ b/tests/phpunit/tests/test-external-cache.php
@@ -8,6 +8,8 @@ class External_Cache_Test extends WP_UnitTestCase {
 
 	/**
 	 * Stores the returned value of wp_using_ext_object_cache().
+	 *
+	 * @var bool
 	 */
 	protected $using_ext_cache;
 

--- a/tests/phpunit/tests/test-external-cache.php
+++ b/tests/phpunit/tests/test-external-cache.php
@@ -6,6 +6,11 @@ class External_Cache_Test extends WP_UnitTestCase {
 
 	const CACHE_GROUP = 'DynaMo';
 
+	/**
+	 * Stores the returned value of wp_using_ext_object_cache().
+	 */
+	protected $using_ext_cache;
+
 	public function set_up() {
 		$this->using_ext_cache = (bool) wp_using_ext_object_cache();
 		wp_using_ext_object_cache( true ); // Fake external object cache.


### PR DESCRIPTION
- Modifies Travis config to test WP 6.2 and PHP 8.2.
- Fixes a missing property decalration to avoid [a deprecated notice in PHP 8.2](https://app.travis-ci.com/github/polylang/dynamo/jobs/604899480).