### PR TITLE
Introduce PHPCS rules planned for WPCS 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
 		"wp-coding-standards/wpcs": "*",
 		"automattic/vipwpcs": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",
+		"phpcsstandards/phpcsextra": "^1.1.0",
 		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"minimum-stability": "dev",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,6 +28,72 @@
 
 	<rule ref="Squiz.Classes.ClassFileName" />
 
+	<!-- The following individual rules are planned for WPCS 3.0 -->
+	<rule ref="Generic.CodeAnalysis.EmptyPHPStatement" />
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterface"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceBeforeLastUsed"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceAfterLastUsed"/>
+	</rule>
+	<rule ref="Generic.VersionControl.GitMergeConflict" />
+	<rule ref="Generic.WhiteSpace.IncrementDecrementSpacing" />
+	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing" />
+	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter" />
+	<rule ref="Modernize.FunctionCalls.Dirname" />
+	<rule ref="NormalizedArrays.Arrays.ArrayBraceSpacing">
+		<properties>
+			<property name="spacesWhenEmpty" value="0"/>
+			<property name="spacesSingleLine" value="1"/>
+			<property name="spacesMultiLine" value="newline"/>
+		</properties>
+	</rule>
+	<rule ref="NormalizedArrays.Arrays.CommaAfterLast" />
+	<rule ref="PSR12.Classes.ClassInstantiation" />
+	<rule ref="PSR12.Files.FileHeader.IncorrectOrder" />
+	<rule ref="PSR12.Files.FileHeader.IncorrectGrouping" />
+	<rule ref="PSR12.Functions.NullableTypeDeclaration" />
+	<rule ref="PSR12.Functions.ReturnTypeDeclaration" />
+	<rule ref="PSR12.Traits.UseDeclaration" />
+	<rule ref="PSR2.Classes.ClassDeclaration" >
+		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine" />
+		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceWrongLine" />
+	</rule>
+	<rule ref="PSR2.Methods.FunctionClosingBrace" />
+	<rule ref="Universal.Arrays.DisallowShortArraySyntax" />
+	<rule ref="Universal.Arrays.DuplicateArrayKey" />
+	<rule ref="Universal.Classes.ModifierKeywordOrder" />
+	<rule ref="Universal.Classes.RequireAnonClassParentheses" />
+	<rule ref="Universal.CodeAnalysis.ConstructorDestructorReturn" />
+	<rule ref="Universal.CodeAnalysis.ForeachUniqueAssignment" />
+	<rule ref="Universal.CodeAnalysis.NoEchoSprintf" />
+	<rule ref="Universal.CodeAnalysis.StaticInFinalClass" />
+	<rule ref="Universal.Constants.LowercaseClassResolutionKeyword" />
+	<rule ref="Universal.Constants.ModifierKeywordOrder" />
+	<rule ref="Universal.Constants.UppercaseMagicConstants" />
+	<rule ref="Universal.ControlStructures.DisallowLonelyIf" />
+	<rule ref="Universal.Files.SeparateFunctionsFromOO" />
+	<rule ref="Universal.Namespaces.DisallowCurlyBraceSyntax" />
+	<rule ref="Universal.Namespaces.DisallowDeclarationWithoutName" />
+	<rule ref="Universal.Namespaces.OneDeclarationPerFile" />
+	<rule ref="Universal.NamingConventions.NoReservedKeywordParameterNames" />
+	<rule ref="Universal.Operators.DisallowShortTernary" />
+	<rule ref="Universal.Operators.DisallowStandalonePostIncrementDecrement" />
+	<rule ref="Universal.Operators.StrictComparisons" />
+	<rule ref="Universal.Operators.TypeSeparatorSpacing" />
+	<rule ref="Universal.UseStatements.DisallowMixedGroupUse" />
+	<rule ref="Universal.UseStatements.KeywordSpacing" />
+	<rule ref="Universal.UseStatements.LowercaseFunctionConst" />
+	<rule ref="Universal.UseStatements.NoLeadingBackslash" />
+	<rule ref="Universal.UseStatements.NoUselessAliases" />
+	<rule ref="Universal.WhiteSpace.AnonClassKeywordSpacing" />
+	<rule ref="Universal.WhiteSpace.CommaSpacing" />
+	<rule ref="Universal.WhiteSpace.DisallowInlineTabs" />
+	<rule ref="Universal.WhiteSpace.PrecisionAlignment" />
+
 	<rule ref="Squiz.Commenting.ClassComment" >
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>

--- a/src/MO_Reader.php
+++ b/src/MO_Reader.php
@@ -128,14 +128,14 @@ abstract class MO_Reader {
 	 *
 	 * @since 1.0
 	 *
-	 * @param string $string The string.
+	 * @param string $the_string The string.
 	 * @return int
 	 */
-	protected static function strlen( $string ) {
+	protected static function strlen( $the_string ) {
 		if ( function_exists( 'mb_strlen' ) && ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
-			return mb_strlen( $string, 'ascii' );
+			return mb_strlen( $the_string, 'ascii' );
 		} else {
-			return strlen( $string );
+			return strlen( $the_string );
 		}
 	}
 

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace WP_Syntex\DynaMo;
 
-use WP_Syntex\DynaMo\Plugin as Plugin;
+use WP_Syntex\DynaMo\Plugin;
 
 class TestCase extends \WP_UnitTestCase {
 

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -9,16 +9,16 @@ class TestCase extends \WP_UnitTestCase {
 	/**
 	 * Initialize the plugin with the provided file loader class.
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	protected function init( $class ) {
+	protected function init( $the_class ) {
 		add_filter(
 			'dynamo_file_loader',
-			function() use ( $class ) {
-				if ( false === strpos( $class, '\MO' ) ) {
-					$class = "WP_Syntex\\DynaMo\\{$class}\\MO";
+			function() use ( $the_class ) {
+				if ( false === strpos( $the_class, '\MO' ) ) {
+					$the_class = "WP_Syntex\\DynaMo\\{$the_class}\\MO";
 				}
-				return new $class();
+				return new $the_class();
 			}
 		);
 		( new Plugin() )->add_hooks();

--- a/tests/phpunit/Tests/ExternalCache.php
+++ b/tests/phpunit/Tests/ExternalCache.php
@@ -2,7 +2,7 @@
 
 namespace WP_Syntex\DynaMo\Tests;
 
-use WP_Syntex\DynaMo\Plugin as Plugin;
+use WP_Syntex\DynaMo\Plugin;
 
 class ExternalCache extends \WP_UnitTestCase {
 

--- a/tests/phpunit/Tests/MO.php
+++ b/tests/phpunit/Tests/MO.php
@@ -15,12 +15,12 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["WP_Syntex\\DynaMo\\Dynamic\\MO"]
 	 *           ["WP_Syntex\\DynaMo\\Full\\MO"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_instance( $class ) {
-		$this->init( $class );
+	public function test_instance( $the_class ) {
+		$this->init( $the_class );
 		load_textdomain( 'domain', TEST_DATA_DIR . 'some_translations.mo' );
-		$this->assertTrue( $GLOBALS['l10n']['domain'] instanceof $class );
+		$this->assertTrue( $GLOBALS['l10n']['domain'] instanceof $the_class );
 	}
 
 	/**
@@ -29,10 +29,10 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["Dynamic"]
 	 *           ["Full"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_unreadable_file( $class ) {
-		$this->init( $class );
+	public function test_unreadable_file( $the_class ) {
+		$this->init( $the_class );
 		load_textdomain( 'domain', 'some_unreadable_file.mo' );
 		$this->assertEmpty( $GLOBALS['l10n'] );
 	}
@@ -43,10 +43,10 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["Dynamic"]
 	 *           ["Full"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_loading_two_files_should_include_strings_of_both_files( $class ) {
-		$this->init( $class );
+	public function test_loading_two_files_should_include_strings_of_both_files( $the_class ) {
+		$this->init( $the_class );
 		load_textdomain( 'default', TEST_DATA_DIR . 'automatic.mo' );
 		load_textdomain( 'default', TEST_DATA_DIR . 'some_translations.mo' );
 
@@ -63,10 +63,10 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["Dynamic"]
 	 *           ["Full"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_loading_two_files_should_not_overwrite_first_strings( $class ) {
-		$this->init( $class );
+	public function test_loading_two_files_should_not_overwrite_first_strings( $the_class ) {
+		$this->init( $the_class );
 		load_textdomain( 'default', TEST_DATA_DIR . 'alternative.mo' );
 		load_textdomain( 'default', TEST_DATA_DIR . 'automatic.mo' );
 
@@ -80,13 +80,13 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["WP_Syntex\\DynaMo\\Dynamic\\MO"]
 	 *           ["WP_Syntex\\DynaMo\\Full\\MO"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_merge_should_keep_other_strings( $class ) {
-		$mo = new $class();
+	public function test_merge_should_keep_other_strings( $the_class ) {
+		$mo = new $the_class();
 		$mo->import_from_file( TEST_DATA_DIR . 'alternative.mo' );
 
-		$other = new $class();
+		$other = new $the_class();
 		$other->import_from_file( TEST_DATA_DIR . 'automatic.mo' );
 
 		$mo->merge_with( $other );
@@ -100,11 +100,11 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["WP_Syntex\\DynaMo\\Dynamic\\MO"]
 	 *           ["WP_Syntex\\DynaMo\\Full\\MO"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_merge_into_WP_MO( $class ) {
+	public function test_merge_into_WP_MO( $the_class ) {
 		$wp_mo  = new \MO();
-		$our_mo = new $class();
+		$our_mo = new $the_class();
 		$wp_mo->merge_with( $our_mo );
 		$this->assertTrue( $wp_mo instanceof \MO );
 	}
@@ -126,10 +126,10 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["WP_Syntex\\DynaMo\\Dynamic\\MO"]
 	 *           ["WP_Syntex\\DynaMo\\Full\\MO"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_load_just_in_time( $class ) {
-		$this->init( $class );
+	public function test_load_just_in_time( $the_class ) {
+		$this->init( $the_class );
 
 		add_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 
@@ -138,7 +138,7 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 		$this->assertFalse( is_textdomain_loaded( 'internationalized-plugin' ) );
 		$this->assertSame( 'Das ist ein Dummy Plugin', i18n_plugin_test() );
 		$this->assertTrue( is_textdomain_loaded( 'internationalized-plugin' ) );
-		$this->assertTrue( $GLOBALS['l10n']['internationalized-plugin'] instanceof $class );
+		$this->assertTrue( $GLOBALS['l10n']['internationalized-plugin'] instanceof $the_class );
 	}
 
 	/**
@@ -149,10 +149,10 @@ class MO extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["Dynamic"]
 	 *           ["Full"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_mofile_without_translations_headers( $class ) {
-		$this->init( $class );
+	public function test_mofile_without_translations_headers( $the_class ) {
+		$this->init( $the_class );
 		load_textdomain( 'gravity_form-1', TEST_DATA_DIR . 'gravity_form-1-de_DE.mo' );
 
 		$this->assertSame( 'First Name', __( 'field-1-label', 'gravity_form-1' ) );

--- a/tests/phpunit/Tests/Specific.php
+++ b/tests/phpunit/Tests/Specific.php
@@ -18,10 +18,10 @@ class Specific extends \WP_Syntex\DynaMo\TestCase {
 	 * @testWith ["Dynamic"]
 	 *           ["Full"]
 	 *
-	 * @param string $class Class loader to instantiate.
+	 * @param string $the_class Class loader to instantiate.
 	 */
-	public function test_shipment_tracking( $class ) {
-		$this->init( $class );
+	public function test_shipment_tracking( $the_class ) {
+		$this->init( $the_class );
 		load_textdomain( 'shipment-tracking', TEST_DATA_DIR . 'woocommerce-shipment-tracking-fr_FR.mo' );
 
 		// Call done by _get_plugin_data_markup_translate().

--- a/tests/phpunit/Tests/Translations.php
+++ b/tests/phpunit/Tests/Translations.php
@@ -8,8 +8,8 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 		unset( $GLOBALS['l10n'] );
 	}
 
-	public function setup_test( $class, $mofile ) {
-		$this->init( $class );
+	public function setup_test( $the_class, $mofile ) {
+		$this->init( $the_class );
 		load_textdomain( 'default', TEST_DATA_DIR . $mofile );
 	}
 
@@ -44,11 +44,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_singular( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_singular( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( '&laquo; Nazaj', __( '&laquo; Previous' ) );
 		$this->assertSame( '&laquo; Prejšnja stran', __( '&laquo; Previous Page' ) );
 		$this->assertSame( 'Omogoči', __( 'Activate' ) );
@@ -60,11 +60,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_with_context( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_with_context( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( 'Kategorija', _x( 'Category', 'taxonomy singular name' ) );
 	}
 
@@ -74,11 +74,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_plurals( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_plurals( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( '%s razpoložljiva posodobitev', _n( '%s update available', '%s updates available', 101 ) ); // 1, 101, 201
 		$this->assertSame( '%s razpoložljivi posodobitvi', _n( '%s update available', '%s updates available', 102 ) ); // 2, 102, 202
 		$this->assertSame( '%s razpoložljive posodobitve', _n( '%s update available', '%s updates available', 103 ) ); // 3, 4, 103
@@ -90,11 +90,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_non_existing_singular( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_non_existing_singular( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( 'Bla Bla Bla', __( 'Bla Bla Bla' ) );
 	}
 
@@ -103,11 +103,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_non_existing_with_context( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_non_existing_with_context( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( 'Bla Bla Bla', _x( 'Bla Bla Bla', 'Any context' ) );
 	}
 
@@ -116,11 +116,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_non_existing_plural( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_non_existing_plural( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( '%s horse galloping in the meadow', _n( '%s horse galloping in the meadow', '%s horses galloping in the meadow', 1 ) );
 		$this->assertSame( '%s horses galloping in the meadow', _n( '%s horse galloping in the meadow', '%s horses galloping in the meadow', 101 ) );
 		$this->assertSame( '%s horses galloping in the meadow', _n( '%s horse galloping in the meadow', '%s horses galloping in the meadow', 102 ) );
@@ -131,11 +131,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_two_times_singular( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_two_times_singular( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( 'november', __( 'November' ) );
 		$this->assertSame( 'november', __( 'November' ) );
 	}
@@ -145,11 +145,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_two_times_with_context( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_two_times_with_context( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( 'novembra', _x( 'November', 'genitive' ) );
 		$this->assertSame( 'novembra', _x( 'November', 'genitive' ) );
 	}
@@ -159,11 +159,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_singular_and_with_context_after( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_singular_and_with_context_after( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( 'november', __( 'November' ) );
 		$this->assertSame( 'novembra', _x( 'November', 'genitive' ) );
 	}
@@ -173,11 +173,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_with_context_and_singular_after( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_with_context_and_singular_after( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( 'novembra', _x( 'November', 'genitive' ) );
 		$this->assertSame( 'november', __( 'November' ) );
 	}
@@ -189,11 +189,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_empty_string( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_empty_string( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( '', translate( '' ) ); // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings, WordPress.WP.I18n.LowLevelTranslationFunction
 	}
 
@@ -204,11 +204,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_singular_plural_form_with_singular_singular_first( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_singular_plural_form_with_singular_singular_first( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( '%s razpoložljiva posodobitev', __( '%s update available' ) );
 		$this->assertSame( '%s razpoložljiva posodobitev', _n( '%s update available', '%s updates available', 1 ) ); // 1, 101, 201
 	}
@@ -220,11 +220,11 @@ class Translations extends \WP_Syntex\DynaMo\TestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param string $class  Class loader to instantiate.
-	 * @param string $mofile Translation file to load.
+	 * @param string $the_class Class loader to instantiate.
+	 * @param string $mofile    Translation file to load.
 	 */
-	public function test_translate_singular_plural_form_with_singular_plural_first( $class, $mofile ) {
-		$this->setup_test( $class, $mofile );
+	public function test_translate_singular_plural_form_with_singular_plural_first( $the_class, $mofile ) {
+		$this->setup_test( $the_class, $mofile );
 		$this->assertSame( '%s razpoložljiva posodobitev', _n( '%s update available', '%s updates available', 1 ) ); // 1, 101, 201
 		$this->assertSame( '%s razpoložljiva posodobitev', __( '%s update available' ) );
 	}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-$_root_dir  = dirname( dirname( __DIR__ ) );
+$_root_dir  = dirname( __DIR__, 2 );
 $_tests_dir = $_root_dir . '/tmp/wordpress-tests-lib';
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
* Don't use don't use reserved keywords as function parameter names.
* Use the `$levels` parameter of `dirname()` which requires PHP 7.0+.